### PR TITLE
Translate front‑end texts to German

### DIFF
--- a/src/client/CheckoutPage.tsx
+++ b/src/client/CheckoutPage.tsx
@@ -10,13 +10,13 @@ type PaymentStatus = 'paid' | 'canceled' | 'error' | 'loading';
 const getHeadingText = (status: PaymentStatus): string => {
   switch (status) {
     case 'paid':
-      return 'Payment Successful!';
+      return 'Zahlung erfolgreich!';
     case 'canceled':
-      return 'Payment Canceled';
+      return 'Zahlung abgebrochen';
     case 'error':
-      return 'Payment Error';
+      return 'Zahlungsfehler';
     default:
-      return 'loading';
+      return 'lade';
   }
 };
 
@@ -58,7 +58,7 @@ export default function CheckoutPage({ user }: { user: User }) {
       <Heading>{getHeadingText(hasPaid)}</Heading>
 
       <Text textAlign='center'>
-        You are being redirected to your profile page... <br />
+        Du wirst zu deinem Profil weitergeleitet... <br />
       </Text>
     </BorderBox>
   );

--- a/src/client/CoverLetterPage.tsx
+++ b/src/client/CoverLetterPage.tsx
@@ -15,7 +15,7 @@ export default function CoverLetterPage() {
 
   const { id } = useParams();
   if (!id) {
-    return <BorderBox>Error: Cover letter ID is required</BorderBox>;
+    return <BorderBox>Fehler: Anschreiben-ID erforderlich</BorderBox>;
   }
 
   const {
@@ -41,7 +41,7 @@ export default function CoverLetterPage() {
     try {
       setEditIsLoading(true);
       if (!id) {
-        throw new Error('Cover letter ID is required');
+        throw new Error('Anschreiben-ID erforderlich');
       }
 
       const editedCoverLetter = await editCoverLetter({ coverLetterId: id, content: textareaState });
@@ -54,7 +54,7 @@ export default function CoverLetterPage() {
       }
     } catch (error) {
       console.error(error);
-      alert('An error occured. Please try again.');
+      alert('Ein Fehler ist aufgetreten. Bitte erneut versuchen.');
     }
     setEditIsLoading(false);
   };
@@ -82,7 +82,7 @@ export default function CoverLetterPage() {
         {coverLetter && (
           <HStack>
             <Tooltip
-              label={isEdited && 'Changes Saved!'}
+              label={isEdited && 'Änderungen gespeichert!'}
               placement='top'
               hasArrow
               isOpen={isEdited}
@@ -90,17 +90,17 @@ export default function CoverLetterPage() {
               closeOnClick={true}
             >
               <Button size='sm' mr={3} onClick={handleClick} isDisabled={false} isLoading={editIsLoading}>
-                Save Changes
+                Änderungen speichern
               </Button>
             </Tooltip>
             <Tooltip
-              label={hasCopied ? 'Copied!' : 'Copy Letter to Clipboard'}
+              label={hasCopied ? 'Kopiert!' : 'Anschreiben kopieren'}
               placement='top'
               hasArrow
               closeOnClick={false}
             >
               <Button colorScheme='purple' size='sm' mr={3} onClick={onCopy}>
-                Copy
+                Kopieren
               </Button>
             </Tooltip>
           </HStack>

--- a/src/client/JobsPage.tsx
+++ b/src/client/JobsPage.tsx
@@ -94,7 +94,7 @@ function JobsPage({ user }: { user: User }) {
   return (
     <VStack gap={1}>
       <BorderBox>
-        <Heading size='md'>Your Jobs</Heading>
+        <Heading size='md'>Deine Jobs</Heading>
         {isLoading && <Spinner />}
         {!!jobs && (
           <Accordion width='100%'>
@@ -109,7 +109,7 @@ function JobsPage({ user }: { user: User }) {
                         </Text>
                         <Spacer />
                         <Text fontSize='sm' color={!job.isCompleted ? 'text-contrast-xs' : 'text-contrast-lg'}>
-                          Applied
+                          Beworben
                         </Text>
                         <Checkbox mx={1} isChecked={job.isCompleted} onChange={(e) => checkboxHandler(e, job)} />
                         <AccordionIcon />
@@ -129,16 +129,16 @@ function JobsPage({ user }: { user: User }) {
                           deleteOnOpen();
                         }}
                       >
-                        Delete
+                        Löschen
                       </Button>
                     </HStack>
                     <VStack alignItems={'space-between'} my={1}>
                       <Text>
-                        <b>Location:</b> {job.location}
+                        <b>Ort:</b> {job.location}
                       </Text>
                       <HStack pb={1}>
                         <Text>
-                          <b>Description:</b>
+                          <b>Beschreibung:</b>
                         </Text>
                         <Button
                           size='xs'
@@ -148,15 +148,15 @@ function JobsPage({ user }: { user: User }) {
                             desOnOpen();
                           }}
                         >
-                          Display
+                          Anzeigen
                         </Button>
                       </HStack>
                       <HStack py={1} justify='space-between'>
                         <Button onClick={() => coverLetterHandler(job)} size='sm'>
-                          Display Cover Letters
+                          Anschreiben anzeigen
                         </Button>
                         <Button colorScheme='purple' onClick={() => updateCoverLetterHandler(job.id)} size='sm'>
-                          Create Additional Cover Letter
+                          Weiteres Anschreiben erstellen
                         </Button>
                       </HStack>
                     </VStack>
@@ -164,13 +164,13 @@ function JobsPage({ user }: { user: User }) {
                 </AccordionItem>
               ))
             ) : (
-              <Text textAlign='center'>no jobs yet...</Text>
+              <Text textAlign='center'>noch keine Jobs...</Text>
             )}
           </Accordion>
         )}
       </BorderBox>
       <Button size='sm' mt={3} colorScheme='purple' alignSelf='flex-end' onClick={() => navigate('/')}>
-        Create New Job
+        Neuen Job erstellen
       </Button>
       {coverLetter && coverLetter.length > 0 && (
         <ModalElement coverLetterData={coverLetter} isOpen={isOpen} onOpen={onOpen} onClose={onClose} />

--- a/src/client/LoginPage.tsx
+++ b/src/client/LoginPage.tsx
@@ -64,7 +64,7 @@ export default function Login() {
       if (!lnUserInfo?.token || !user) {
         clearInterval(interval);
         setLnIsLoading(false);
-        alert('Login timed out. Please try again.');
+        alert('Anmeldung abgebrochen. Bitte erneut versuchen.');
       }
     }, 60000);
   };
@@ -77,11 +77,11 @@ export default function Login() {
         ) : (
           <VStack>
             <a href={signInUrl}>
-              <Button leftIcon={<AiOutlineGoogle />}>Google Sign In</Button>
+              <Button leftIcon={<AiOutlineGoogle />}>Mit Google anmelden</Button>
             </a>
             <Button isLoading={lnIsLoading} onClick={handleWalletClick} leftIcon={<BsCurrencyBitcoin />}>
               {' '}
-              Lightning Sign In
+              Mit Lightning anmelden
             </Button>
           </VStack>
         )}

--- a/src/client/MainPage.tsx
+++ b/src/client/MainPage.tsx
@@ -316,7 +316,7 @@ function MainPage() {
 
   function setLoadingText() {
     setLoadingTextTimeout = setTimeout(() => {
-      loadingTextRef.current && (loadingTextRef.current.innerText = ' patience, my friend 🧘...');
+      loadingTextRef.current && (loadingTextRef.current.innerText = ' Geduld, mein Freund 🧘...');
     }, 2000);
   }
 
@@ -374,7 +374,7 @@ function MainPage() {
         >
 
             <Heading size={'md'} alignSelf={'start'} mb={3} w='full'>
-              Job Info {isCoverLetterUpdate && <Code ml={1}>Editing...</Code>}
+              Job-Informationen {isCoverLetterUpdate && <Code ml={1}>Bearbeitung...</Code>}
             </Heading>
 
           {showSpinner && <Spinner />}
@@ -385,7 +385,7 @@ function MainPage() {
                   id='title'
                   borderRadius={0}
                   borderTopRadius={7}
-                  placeholder='job title'
+                  placeholder='Jobtitel'
                   {...register('title', {
                     required: 'This is required',
                     minLength: {
@@ -407,7 +407,7 @@ function MainPage() {
                 <Input
                   id='company'
                   borderRadius={0}
-                  placeholder='company'
+                  placeholder='Unternehmen'
                   {...register('company', {
                     required: 'This is required',
                     minLength: {
@@ -423,7 +423,7 @@ function MainPage() {
                 <Input
                   id='location'
                   borderRadius={0}
-                  placeholder='location'
+                  placeholder='Ort'
                   {...register('location', {
                     required: 'This is required',
                     minLength: {
@@ -439,7 +439,7 @@ function MainPage() {
                 <Textarea
                   id='description'
                   borderRadius={0}
-                  placeholder='copy & paste the job description in any language'
+                  placeholder='Kopiere die Stellenbeschreibung in beliebiger Sprache'
                   {...register('description', {
                     required: 'This is required',
                   })}
@@ -453,7 +453,7 @@ function MainPage() {
                   id='pdf'
                   type='file'
                   accept='application/pdf'
-                  placeholder='pdf'
+                  placeholder='PDF'
                   {...register('pdf', {
                     required: 'Please upload a CV/Resume',
                   })}
@@ -480,14 +480,14 @@ function MainPage() {
                   <HStack>
                     <FormLabel textAlign='center' htmlFor='pdf'>
                       <Button size='sm' colorScheme='contrast' onClick={handleFileButtonClick}>
-                        Upload CV
+                        Lebenslauf hochladen
                       </Button>
                     </FormLabel>
-                    {isPdfReady && <Text fontSize={'sm'}>👍 uploaded</Text>}
+                    {isPdfReady && <Text fontSize={'sm'}>👍 hochgeladen</Text>}
                     <FormErrorMessage>{!!formErrors.pdf && formErrors.pdf.message?.toString()}</FormErrorMessage>
                   </HStack>
                   <FormHelperText mt={0.5} fontSize={'xs'}>
-                    Upload a PDF only of Your CV/Resumé
+                    Lade nur eine PDF deines Lebenslaufs hoch
                   </FormHelperText>
                 </VStack>
               </FormControl>
@@ -571,7 +571,7 @@ function MainPage() {
                       color: 'text-contrast-lg',
                     }}
                   >
-                    cover letter creativity level
+                    Kreativitätsgrad des Anschreibens
                   </FormLabel>
                 </FormControl>
               </VStack>
@@ -602,7 +602,7 @@ function MainPage() {
                       color: 'text-contrast-lg',
                     }}
                   >
-                    include a witty remark at the end of the letter
+                    Einen witzigen Satz am Ende des Anschreibens hinzufügen
                   </FormLabel>
                 </FormControl>
               </VStack>
@@ -615,7 +615,7 @@ function MainPage() {
                   disabled={user === null}
                   type='submit'
                 >
-                  {!isCoverLetterUpdate ? 'Generate Cover Letter' : 'Create New Cover Letter'}
+                  {!isCoverLetterUpdate ? 'Anschreiben generieren' : 'Neues Anschreiben erstellen'}
                 </Button>
                 <Text ref={loadingTextRef} fontSize='sm' fontStyle='italic' color='text-contrast-md'>
                   {' '}
@@ -626,7 +626,7 @@ function MainPage() {
           {showJobNotFound && (
             <>
               <Text fontSize='sm' color='text-contrast-md'>
-                Can't find that job...
+                Job nicht gefunden...
               </Text>
             </>
           )}

--- a/src/client/ProfilePage.tsx
+++ b/src/client/ProfilePage.tsx
@@ -60,9 +60,9 @@ export default function ProfilePage({ user }: { user: User }) {
             </VStack>
           ) : userInfo.hasPaid && !userInfo.isUsingLn ? (
             <VStack gap={3} pt={5} alignItems='flex-start'>
-              <Text textAlign='initial'>Thanks so much for your support!</Text>
+              <Text textAlign='initial'>Vielen Dank für deine Unterstützung!</Text>
 
-              <Text textAlign='initial'>You have unlimited access to CoverLetterGPT using {user?.gptModel === 'gpt-4' || user?.gptModel === 'gpt-4o' ? 'GPT-4o.' : 'GPT-4o-mini.'}</Text>
+              <Text textAlign='initial'>Du hast unbegrenzten Zugriff auf CoverLetterGPT mit {user?.gptModel === 'gpt-4' || user?.gptModel === 'gpt-4o' ? 'GPT-4o.' : 'GPT-4o-mini.'}</Text>
 
               {userInfo.subscriptionStatus === 'canceled' && (
                 <Code alignSelf='center' fontSize='lg'>
@@ -79,9 +79,9 @@ export default function ProfilePage({ user }: { user: User }) {
           ) : (
             !userInfo.isUsingLn && (
               <HStack pt={3} textAlign='center'>
-                <Heading size='sm'>You have </Heading>
+                <Heading size='sm'>Du hast </Heading>
                 <Code>{userInfo?.credits ? userInfo.credits : '0'}</Code>
-                <Heading size='sm'>cover letter{userInfo?.credits === 1 ? '' : 's'} left</Heading>
+                <Heading size='sm'>Anschreiben verbleibend</Heading>
               </HStack>
             )
           )}
@@ -114,14 +114,14 @@ export default function ProfilePage({ user }: { user: User }) {
                     <VStack gap={3} alignItems='start'>
                       <Heading size='xl'>$2.95</Heading>
                       <Text textAlign='start' fontSize='md'>
-                        Unlimited
+                        Unbegrenztes
                         <br />
-                        monthly subscription
+                        Monatsabo
                       </Text>
-                      <Heading size='md'>Using GPT-4o-mini 🚀</Heading>
+                      <Heading size='md'>Nutze GPT-4o-mini 🚀</Heading>
                     </VStack>
                     <Button mr={3} isLoading={isLoading} onClick={handleBuy4oMini}>
-                      Buy Now!
+                      Jetzt kaufen!
                     </Button>
                   </VStack>
                   <VStack layerStyle='cardMd' borderColor={'purple.200'} borderWidth={3} py={5} px={7} gap={3} height='100%' width='100%' justifyContent='space-between' alignItems='center'>
@@ -129,12 +129,12 @@ export default function ProfilePage({ user }: { user: User }) {
                       <Heading size='xl'>$5.95</Heading>
 
                       <Text textAlign='start' fontSize='md'>
-                        Unlimited <br /> monthly subscription
+                        Unbegrenztes <br /> Monatsabo
                       </Text>
-                      <Heading size='md'>Using GPT-4o 🤖</Heading>
+                      <Heading size='md'>Nutze GPT-4o 🤖</Heading>
                     </VStack>
                     <Button colorScheme='purple' mr={3} isLoading={isGpt4loading} onClick={handleBuy4o}>
-                      💰 Buy Now!
+                      💰 Jetzt kaufen!
                     </Button>
                   </VStack>
                 </HStack>
@@ -149,10 +149,10 @@ export default function ProfilePage({ user }: { user: User }) {
                     <VStack gap={3} alignItems='center'>
                       <Heading size='xl'>⚡️</Heading>
                       <Text textAlign='start' fontSize='md'>
-                        You have affordable, pay-per-use access to CoverLetterGPT with GPT-4o via the Lightning Network
+                        Du hast günstigen Pay-per-Use-Zugang zu CoverLetterGPT mit GPT-4o über das Lightning-Netzwerk
                       </Text>
                       <Text textAlign='start' fontSize='sm'>
-                        Note: if you prefer a montly subscription, please logout and sign in with Google.
+                        Hinweis: Wenn du ein Monatsabo bevorzugst, melde dich bitte ab und melde dich mit Google an.
                       </Text>
                     </VStack>
                   </VStack>
@@ -161,7 +161,7 @@ export default function ProfilePage({ user }: { user: User }) {
             </VStack>
           )}
           <Button alignSelf='flex-end' size='sm' onClick={() => logout()}>
-            Logout
+            Abmelden
           </Button>
         </>
       ) : (

--- a/src/client/components/AlertDialog.tsx
+++ b/src/client/components/AlertDialog.tsx
@@ -108,11 +108,11 @@ export function LoginToBegin({ isOpen, onClose }: { isOpen: boolean; onOpen: () 
             ✋
           </AlertDialogHeader>
 
-          <AlertDialogBody textAlign='center'>Please Login to Begin!</AlertDialogBody>
+          <AlertDialogBody textAlign='center'>Bitte melden Sie sich an, um zu beginnen!</AlertDialogBody>
 
           <AlertDialogFooter justifyContent='center'>
             <Button ref={loginRef} leftIcon={<AiOutlineLogin />} colorScheme='purple' onClick={handleClick}>
-              Login
+              Anmelden
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -139,13 +139,13 @@ export function DeleteJob({
       <AlertDialogOverlay backdropFilter='auto' backdropInvert='15%' backdropBlur='2px'>
         <AlertDialogContent bgColor='bg-modal'>
           <AlertDialogHeader fontSize='md' mt={3} fontWeight='bold'>
-            ⛔️ Delete Job
+            ⛔️ Job löschen
           </AlertDialogHeader>
 
           <AlertDialogBody>
-            Delete the job and all its cover letters?
+            Den Job und alle zugehörigen Anschreiben löschen?
             <br />
-            This action cannot be undone.
+            Diese Aktion kann nicht rückgängig gemacht werden.
           </AlertDialogBody>
 
           <AlertDialogFooter display='grid' gridTemplateColumns='1fr 1fr 1fr'>
@@ -161,11 +161,11 @@ export function DeleteJob({
                 onClose();
               }}
             >
-              Delete
+              Löschen
             </Button>
             <Spacer />
             <Button ref={cancelRef} size='sm' colorScheme='purple' onClick={onClose}>
-              Cancel
+              Abbrechen
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -197,33 +197,33 @@ export function EditAlert({ coverLetter }: { coverLetter: boolean }) {
       <AlertDialogOverlay backdropFilter='auto' backdropInvert='15%' backdropBlur='2px'>
         <AlertDialogContent bgColor='bg-modal'>
           <AlertDialogHeader fontSize='md' mt={3} fontWeight='bold'>
-            📝 Your cover letter is ready!
+            📝 Ihr Anschreiben ist fertig!
           </AlertDialogHeader>
 
           <AlertDialogBody gap={5} pointerEvents='none'>
             <Text pb={3}>
-              If you want to make finer edits, highlight the text you'd like to change to access the pop-up below:
+              Wenn Sie Feinabstimmungen vornehmen möchten, markieren Sie den gewünschten Text, um das folgende Pop-up zu öffnen:
             </Text>
             <VStack m={3} gap={1} borderRadius='lg'>
               <Box layerStyle='cardLg' p={3}>
                 <Text fontSize='sm' textAlign='center'>
-                  🤔 Ask GPT to make this part more..
+                  🤔 GPT um Verbesserungen bitten...
                 </Text>
                 <ButtonGroup size='xs' p={1} variant='solid' colorScheme='purple' isAttached>
                   <Button size='xs' color='black' fontSize='xs'>
-                    Concise
+                    Kürzer
                   </Button>
 
                   <Button size='xs' color='black' fontSize='xs'>
-                    Detailed
+                    Ausführlicher
                   </Button>
 
                   <Button size='xs' color='black' fontSize='xs'>
-                    Professional
+                    Professioneller
                   </Button>
 
                   <Button size='xs' color='black' fontSize='xs'>
-                    Informal
+                    Lockerer
                   </Button>
                 </ButtonGroup>
               </Box>
@@ -232,7 +232,7 @@ export function EditAlert({ coverLetter }: { coverLetter: boolean }) {
 
           <AlertDialogFooter justifyContent='space-between'>
             <Checkbox onChange={handleCheckboxChange} size='sm' color='text-contrast-md'>
-              Don't show me this again
+              Nicht mehr anzeigen
             </Checkbox>
             <Button ref={cancelRef} size='sm' colorScheme='purple' onClick={onClose}>
               OK

--- a/src/client/components/CallToAction.tsx
+++ b/src/client/components/CallToAction.tsx
@@ -11,7 +11,7 @@ export function Footer() {
           <HStack justify='center'>
             <FaGithub />
             <Text fontSize='sm' color='purple.300'>
-              Built with Wasp & 100% Open-Source
+              Entwickelt mit Wasp & komplett Open Source
             </Text>
           </HStack>
         </Link>
@@ -20,18 +20,18 @@ export function Footer() {
           <HStack justify='center'>
             <FaTwitter />
             <Text fontSize='sm' color='purple.300'>
-              Follow me on Txitter
+              Folge mir auf Txitter
             </Text>
           </HStack>
         </Link>
         <WaspLink to='/tos'>
           <Text fontSize='sm' color='purple.300'>
-            Terms of Service
+            Nutzungsbedingungen
           </Text>
         </WaspLink>
         <WaspLink to='/privacy'>
           <Text fontSize='sm' color='purple.300'>
-            Privacy Policy
+            Datenschutzrichtlinie
           </Text>
         </WaspLink>
       </VStack>

--- a/src/client/components/DescriptionModal.tsx
+++ b/src/client/components/DescriptionModal.tsx
@@ -27,7 +27,7 @@ export default function DescriptionModal({ description, isOpen, onClose, onOpen 
     <Modal isOpen={isOpen} onClose={onClose} initialFocusRef={copyButtonRef}>
       <ModalOverlay backdropFilter='auto' backdropInvert='15%' backdropBlur='2px' />
       <ModalContent maxH='lg' maxW='lg' bgColor='bg-modal'>
-        <ModalHeader>Job Description</ModalHeader>
+        <ModalHeader>Stellenbeschreibung</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
           <Textarea
@@ -47,7 +47,7 @@ export default function DescriptionModal({ description, isOpen, onClose, onOpen 
 
         <ModalFooter>
           <Button size='sm' variant='outline' onClick={onClose}>
-            Close
+            Schließen
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/src/client/components/LnLoginModal.tsx
+++ b/src/client/components/LnLoginModal.tsx
@@ -63,19 +63,19 @@ export default function LoginModal({ status, encodedUrl, isOpen, onClose, handle
     <Modal isOpen={isOpen} onClose={onClose} initialFocusRef={buttonRef} >
       <ModalOverlay backdropFilter='auto' backdropInvert='15%' backdropBlur='2px' />
       <ModalContent maxH='lg' maxW='lg' bgColor='bg-modal'>
-        <ModalHeader>Lightning Login</ModalHeader>
+        <ModalHeader>Lightning-Anmeldung</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
           <VStack gap={3}>
             <Box>{content}</Box>
             <HStack>
               <Button id='copy-button' onClick={handleCopyClick}>
-                Copy
+                Kopieren
               </Button>
               {!!encodedUrl && (
                 <a href={`lightning:${encodedUrl}`}>
                   <Button id='open-button' onClick={handleWalletClick} ref={buttonRef}>
-                    Login with ⚡ Wallet
+                    Mit ⚡ Wallet anmelden
                   </Button>
                 </a>
               )}
@@ -84,7 +84,7 @@ export default function LoginModal({ status, encodedUrl, isOpen, onClose, handle
         </ModalBody>
         <ModalFooter>
           <Button size='sm' variant='outline' onClick={onClose}>
-            Close
+            Schließen
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/src/client/components/LnPaymentModal.tsx
+++ b/src/client/components/LnPaymentModal.tsx
@@ -183,22 +183,22 @@ export default function LnPaymentModal({ lightningInvoice, isOpen, onClose }: In
     <Modal isOpen={isOpen} onClose={handleCloseClick} initialFocusRef={copyButtonRef}>
       <ModalOverlay backdropFilter='auto' backdropInvert='15%' backdropBlur='2px' />
       <ModalContent maxH='lg' maxW='lg' bgColor='bg-modal'>
-        <ModalHeader>Lightning Invoice</ModalHeader>
+        <ModalHeader>Lightning-Rechnung</ModalHeader>
         <ModalCloseButton visibility={isPaying ? 'hidden' : 'visible'} />
         <ModalBody>
           <VStack gap={3}>
             <Box>{content}</Box>
             <p className='mb-2 text-center'>
-              Pay ~${amountCents ? amountCents.toFixed(2) : <Spinner size='xs' mx={4} />} for the API call
+              Bezahle ~${amountCents ? amountCents.toFixed(2) : <Spinner size='xs' mx={4} />} für den API-Aufruf
             </p>
             <HStack gap={3} visibility={isPaying ? 'hidden' : 'visible'}>
               <Button id='copy-button' ref={copyButtonRef} onClick={handleCopyClick}>
-                Copy
+                Kopieren
               </Button>
               {!!lightningInvoice && (
                 <a href={`lightning:${lightningInvoice.pr}`}>
                   <Button id='open-button' onClick={() => setIsPaying(true)}>
-                    Open in ⚡ Wallet
+                    In ⚡ Wallet öffnen
                   </Button>
                 </a>
               )}
@@ -207,7 +207,7 @@ export default function LnPaymentModal({ lightningInvoice, isOpen, onClose }: In
         </ModalBody>
         <ModalFooter>
           <Button size='sm' variant='outline' isDisabled={isPaying} onClick={handleCloseClick}>
-            Close
+            Schließen
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/src/client/components/Modal.tsx
+++ b/src/client/components/Modal.tsx
@@ -50,12 +50,12 @@ export default function ModalElement({ coverLetterData, isOpen, onOpen, onClose 
     <Modal isOpen={isOpen} onClose={onClose} initialFocusRef={copyButtonRef}>
       <ModalOverlay backdropFilter='auto' backdropInvert='15%' backdropBlur='2px' />
       <ModalContent maxH='2xl' maxW='2xl' bgColor='bg-modal'>
-        <ModalHeader>Your Cover Letter{coverLetterData.length > 1 && 's'}</ModalHeader>
+        <ModalHeader>Ihr Anschreiben{coverLetterData.length > 1 && 'e'}</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
           {coverLetterData.length > 1 && (
             <Select
-              placeholder='Select Cover Letter'
+              placeholder='Anschreiben auswählen'
               defaultValue={selectedCoverLetter.id}
               onChange={handleSelectChange}
             >
@@ -83,13 +83,13 @@ export default function ModalElement({ coverLetterData, isOpen, onOpen, onClose 
 
         <ModalFooter>
           <Tooltip
-            label={hasCopied ? 'Copied!' : 'Copy Letter to Clipboard'}
+            label={hasCopied ? 'Kopiert!' : 'Anschreiben kopieren'}
             placement='top'
             hasArrow
             closeOnClick={false}
           >
             <Button ref={copyButtonRef} colorScheme='purple' size='sm' mr={3} onClick={onCopy}>
-              Copy
+              Kopieren
             </Button>
           </Tooltip>
           <Button
@@ -100,7 +100,7 @@ export default function ModalElement({ coverLetterData, isOpen, onOpen, onClose 
             mr={3}
             onClick={() => navigate(`/cover-letter/${selectedCoverLetter.id}`)}
           >
-            Edit
+            Bearbeiten
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/src/client/components/NavBar.tsx
+++ b/src/client/components/NavBar.tsx
@@ -60,23 +60,23 @@ export default function NavBar() {
         {user ? (
           <>
             <NavButton icon={<MdWorkOutline />} to='/jobs'>
-              Jobs Dashboard
+              Jobübersicht
             </NavButton>
             <Spacer maxW='3px' />
             <NavButton icon={<CgProfile />} to='/profile'>
-              Account
+              Konto
             </NavButton>
             <MobileButton icon={<AiOutlineMenu />} isUser={true}>
-              Menu
+              Menü
             </MobileButton>
           </>
         ) : (
           <>
             <NavButton icon={<CgProfile />} to='/login'>
-              Login
+              Anmelden
             </NavButton>
             <MobileButton icon={<AiOutlineMenu />} isUser={false}>
-              Menu
+              Menü
             </MobileButton>
           </>
         )}
@@ -140,16 +140,16 @@ function MobileButton({
         {isUser ? (
           <>
             <Link as={RouterLink} to={`/jobs`}>
-              <MenuItem>Jobs Dashboard</MenuItem>
+              <MenuItem>Jobübersicht</MenuItem>
             </Link>
             <Link as={RouterLink} to={`/profile`}>
-              <MenuItem>Account</MenuItem>
+              <MenuItem>Konto</MenuItem>
             </Link>
           </>
         ) : (
           <>
             <Link as={RouterLink} to='/login'>
-              <MenuItem>Login</MenuItem>
+              <MenuItem>Anmelden</MenuItem>
             </Link>
           </>
         )}

--- a/src/client/components/Popover.tsx
+++ b/src/client/components/Popover.tsx
@@ -126,23 +126,23 @@ export function EditPopover({ setTooltip, selectedText, user, ...props }: EditPo
       <VStack {...props} gap={1} bgColor='bg-modal' borderRadius='lg' boxShadow='2xl'>
         <Box layerStyle='cardLg' p={3}>
           <Text fontSize='sm' textAlign='center'>
-            🤔 Ask GPT to make this part more..
+            🤔 GPT um Verbesserungen bitten...
           </Text>
           <ButtonGroup size='xs' p={1} variant='solid' colorScheme='purple' isAttached>
             <Button size='xs' color='black' fontSize='xs' onClick={() => handleClick('concise')}>
-              Concise
+              Kürzer
             </Button>
 
             <Button size='xs' color='black' fontSize='xs' onClick={() => handleClick('detailed')}>
-              Detailed
+              Ausführlicher
             </Button>
 
             <Button size='xs' color='black' fontSize='xs' onClick={() => handleClick('Professional')}>
-              Professional
+              Professioneller
             </Button>
 
             <Button size='xs' color='black' fontSize='xs' onClick={() => handleClick('informal')}>
-              Informal
+              Lockerer
             </Button>
           </ButtonGroup>
         </Box>

--- a/src/client/legal/PrivacyPolicyPage.tsx
+++ b/src/client/legal/PrivacyPolicyPage.tsx
@@ -22,7 +22,7 @@ const PrivacyPolicy = () => {
 
         <LegalSection title='1. Einleitung'>
           <Text>
-            Canger & Shahab Crimpin GbR ("wir" oder "uns") betreibt CoverLetterGPT.
+            ("wir" oder "uns") betreibt CoverLetterGPT.
             Diese Seite informiert Sie über unsere Richtlinien zur Erhebung,
             Nutzung und Offenlegung personenbezogener Daten, wenn Sie unseren Dienst
             nutzen, sowie über Ihre Wahlmöglichkeiten in Bezug auf diese Daten.
@@ -33,11 +33,11 @@ const PrivacyPolicy = () => {
           <Text>
             Verantwortlich für Ihre personenbezogenen Daten ist:
             <br />
-            Canger & Shahab Crimpin GbR
+           GbR
             <br />
-            Zum Steinberg 12, 69121 Heidelberg, Deutschland
+            ZDeutschland
             <br />
-            E-Mail: info.crimpin@gmail.com
+            E-Mail: @gmail.com
           </Text>
         </LegalSection>
 

--- a/src/client/legal/PrivacyPolicyPage.tsx
+++ b/src/client/legal/PrivacyPolicyPage.tsx
@@ -17,229 +17,221 @@ const PrivacyPolicy = () => {
   return (
     <BorderBox>
       <VStack maxW='4xl' mx='auto' p={6} spacing={6} align='flex-start'>
-        <Heading as='h1' size='xl' mb={6}>Privacy Policy</Heading>
+        <Heading as='h1' size='xl' mb={6}>Datenschutzerklärung</Heading>
         <Text fontSize='sm' color='gray.600' mb={6}>Last updated: {new Date().toLocaleDateString()}</Text>
 
-        <LegalSection title='1. Introduction'>
+        <LegalSection title='1. Einleitung'>
           <Text>
-            Canger & Shahab Crimpin GbR ("we", "us", or "our") operates CoverLetterGPT. 
-            This page informs you of our policies regarding the collection, use, and 
-            disclosure of personal data when you use our Service and the choices you 
-            have associated with that data.
+            Canger & Shahab Crimpin GbR ("wir" oder "uns") betreibt CoverLetterGPT.
+            Diese Seite informiert Sie über unsere Richtlinien zur Erhebung,
+            Nutzung und Offenlegung personenbezogener Daten, wenn Sie unseren Dienst
+            nutzen, sowie über Ihre Wahlmöglichkeiten in Bezug auf diese Daten.
           </Text>
         </LegalSection>
 
-        <LegalSection title='2. Data Controller Information'>
+        <LegalSection title='2. Verantwortlicher'>
           <Text>
-            The data controller for your personal data is:
+            Verantwortlich für Ihre personenbezogenen Daten ist:
             <br />
             Canger & Shahab Crimpin GbR
             <br />
-            Zum Steinberg 12, 69121 Heidelberg, Germany
+            Zum Steinberg 12, 69121 Heidelberg, Deutschland
             <br />
-            Email: info.crimpin@gmail.com
+            E-Mail: info.crimpin@gmail.com
           </Text>
         </LegalSection>
 
-        <LegalSection title='3. Data We Collect'>
-          <Text mb={4}>We collect several different types of information for various purposes:</Text>
+        <LegalSection title='3. Welche Daten wir erheben'>
+          <Text mb={4}>Wir erfassen unterschiedliche Kategorien personenbezogener Daten für verschiedene Zwecke:</Text>
           <UnorderedList spacing={4}>
             <ListItem>
-              <Text fontWeight='semibold'>Account Data:</Text>
+              <Text fontWeight='semibold'>Kontodaten:</Text>
               <UnorderedList ml={6} mt={2} spacing={2}>
-                <ListItem>Email address</ListItem>
+                <ListItem>E-Mail-Adresse</ListItem>
                 <ListItem>Name</ListItem>
-                <ListItem>Password (encrypted)</ListItem>
-                <ListItem>Profile information</ListItem>
-                <ListItem>Account settings</ListItem>
+                <ListItem>Passwort (verschlüsselt)</ListItem>
+                <ListItem>Profilinformationen</ListItem>
+                <ListItem>Kontoeinstellungen</ListItem>
               </UnorderedList>
             </ListItem>
             <ListItem>
-              <Text fontWeight='semibold'>Usage Data:</Text>
+              <Text fontWeight='semibold'>Nutzungsdaten:</Text>
               <UnorderedList ml={6} mt={2} spacing={2}>
-                <ListItem>Access times and dates</ListItem>
+                <ListItem>Zugriffszeiten und -daten</ListItem>
               </UnorderedList>
             </ListItem>
             <ListItem>
-              <Text fontWeight='semibold'>Content Data:</Text>
+              <Text fontWeight='semibold'>Inhaltsdaten:</Text>
               <UnorderedList ml={6} mt={2} spacing={2}>
-                <ListItem>CV information you provide</ListItem>
-                <ListItem>Job descriptions you input</ListItem>
-                <ListItem>Generated (example)cover letters</ListItem>
+                <ListItem>Von Ihnen bereitgestellte Lebenslaufdaten</ListItem>
+                <ListItem>Von Ihnen eingegebene Stellenbeschreibungen</ListItem>
+                <ListItem>Generierte Beispielanschreiben</ListItem>
               </UnorderedList>
             </ListItem>
             <ListItem>
-              <Text fontWeight='semibold'>Payment Data:</Text>
+              <Text fontWeight='semibold'>Zahlungsdaten:</Text>
               <UnorderedList ml={6} mt={2} spacing={2}>
-                <ListItem>Payment history</ListItem>
-                <ListItem>Subscription status</ListItem>
-                <ListItem>Note: Payment processing is handled by Stripe</ListItem>
+                <ListItem>Zahlungshistorie</ListItem>
+                <ListItem>Abonnementstatus</ListItem>
+                <ListItem>Hinweis: Die Zahlungsabwicklung erfolgt über Stripe</ListItem>
               </UnorderedList>
             </ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title='4. How We Use Your Data'>
+        <LegalSection title='4. Wie wir Ihre Daten verwenden'>
           <UnorderedList spacing={4}>
             <ListItem>
-              <Text fontWeight='semibold'>To Provide Our Service:</Text>
+              <Text fontWeight='semibold'>Zur Bereitstellung unseres Dienstes:</Text>
               <UnorderedList ml={6} mt={2} spacing={2}>
-                <ListItem>Generate personalized cover letters</ListItem>
-                <ListItem>Manage your account</ListItem>
-                <ListItem>Process your payments</ListItem>
+                <ListItem>Personalisierte Anschreiben generieren</ListItem>
+                <ListItem>Ihr Konto verwalten</ListItem>
+                <ListItem>Ihre Zahlungen abwickeln</ListItem>
               </UnorderedList>
             </ListItem>
             <ListItem>
-              <Text fontWeight='semibold'>To Improve Our Service:</Text>
+              <Text fontWeight='semibold'>Zur Verbesserung unseres Dienstes:</Text>
               <UnorderedList ml={6} mt={2} spacing={2}>
-                <ListItem>Analyze usage patterns</ListItem>
-                <ListItem>Debug technical issues</ListItem>
-                <ListItem>Enhance user experience</ListItem>
+                <ListItem>Nutzungsmuster analysieren</ListItem>
+                <ListItem>Technische Probleme beheben</ListItem>
+                <ListItem>Benutzererfahrung verbessern</ListItem>
               </UnorderedList>
             </ListItem>
             <ListItem>
-              <Text fontWeight='semibold'>To Communicate With You:</Text>
+              <Text fontWeight='semibold'>Zur Kommunikation mit Ihnen:</Text>
               <UnorderedList ml={6} mt={2} spacing={2}>
-                <ListItem>Send service updates</ListItem>
-                <ListItem>Respond to your requests</ListItem>
-                <ListItem>Provide customer support</ListItem>
+                <ListItem>Service-Updates versenden</ListItem>
+                <ListItem>Auf Ihre Anfragen reagieren</ListItem>
+                <ListItem>Kundensupport bieten</ListItem>
               </UnorderedList>
             </ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title='5. Legal Basis for Processing'>
+        <LegalSection title='5. Rechtsgrundlagen der Verarbeitung'>
           <UnorderedList spacing={4}>
             <ListItem>
-              <Text fontWeight='semibold' as='span'>Contract Performance: </Text>
-              Processing necessary for the performance of our contract with you
+              <Text fontWeight='semibold' as='span'>Vertragserfüllung: </Text>
+              Verarbeitung, die für die Erfüllung unseres Vertrags mit Ihnen erforderlich ist
             </ListItem>
             <ListItem>
-              <Text fontWeight='semibold' as='span'>Legal Obligations: </Text>
-              Processing necessary for compliance with legal obligations
+              <Text fontWeight='semibold' as='span'>Gesetzliche Verpflichtungen: </Text>
+              Verarbeitung, die zur Einhaltung gesetzlicher Pflichten notwendig ist
             </ListItem>
             <ListItem>
-              <Text fontWeight='semibold' as='span'>Legitimate Interests: </Text>
-              Processing based on our legitimate interests in improving and promoting our services
+              <Text fontWeight='semibold' as='span'>Berechtigte Interessen: </Text>
+              Verarbeitung aufgrund unserer berechtigten Interessen an der Verbesserung und Vermarktung unserer Dienste
             </ListItem>
             <ListItem>
-              <Text fontWeight='semibold' as='span'>Consent: </Text>
-              Processing based on your specific consent where required
+              <Text fontWeight='semibold' as='span'>Einwilligung: </Text>
+              Verarbeitung auf Grundlage Ihrer ausdrücklichen Einwilligung, sofern erforderlich
             </ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title='6. Data Retention'>
+        <LegalSection title='6. Speicherdauer'>
           <Text mb={4}>
-            We retain your personal data only for as long as necessary to fulfill the 
-            purposes for which we collected it, including:
+            Wir bewahren Ihre personenbezogenen Daten nur so lange auf, wie dies zur Erfüllung
+            der Zwecke erforderlich ist, für die wir sie erhoben haben:
           </Text>
           <UnorderedList spacing={2}>
-            <ListItem>Account data: As long as your account is active</ListItem>
-            <ListItem>Generated content: For as long as necessary to provide our services or until you delete your account</ListItem>
-            <ListItem>Payment records: As required by tax laws (typically 10 years in Germany)</ListItem>
+            <ListItem>Kontodaten: solange Ihr Konto aktiv ist</ListItem>
+            <ListItem>Generierte Inhalte: solange notwendig zur Bereitstellung unserer Dienste oder bis zur Löschung Ihres Kontos</ListItem>
+            <ListItem>Zahlungsnachweise: gemäß steuerrechtlichen Vorgaben (in Deutschland meist 10 Jahre)</ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title='7. Your Data Protection Rights'>
-          <Text mb={4}>Under GDPR, you have the following rights:</Text>
+        <LegalSection title='7. Ihre Datenschutzrechte'>
+          <Text mb={4}>Nach der DSGVO stehen Ihnen insbesondere folgende Rechte zu:</Text>
           <UnorderedList spacing={2} mb={4}>
-            <ListItem>Right to access your personal data</ListItem>
-            <ListItem>Right to rectification of inaccurate data</ListItem>
-            <ListItem>Right to erasure ("right to be forgotten")</ListItem>
-            <ListItem>Right to restrict processing</ListItem>
-            <ListItem>Right to data portability</ListItem>
-            <ListItem>Right to object to processing</ListItem>
-            <ListItem>Right to withdraw consent</ListItem>
+            <ListItem>Auskunft über Ihre gespeicherten personenbezogenen Daten</ListItem>
+            <ListItem>Berichtigung unrichtiger Daten</ListItem>
+            <ListItem>Löschung Ihrer Daten ("Recht auf Vergessenwerden")</ListItem>
+            <ListItem>Einschränkung der Verarbeitung</ListItem>
+            <ListItem>Datenübertragbarkeit</ListItem>
+            <ListItem>Widerspruch gegen die Verarbeitung</ListItem>
+            <ListItem>Widerruf erteilter Einwilligungen</ListItem>
           </UnorderedList>
           <Text>
-            To exercise these rights, please contact us at info.crimpin@gmail.com
+            Zur Ausübung dieser Rechte kontaktieren Sie uns bitte unter info.crimpin@gmail.com
           </Text>
         </LegalSection>
 
-        <LegalSection title='8. Data Sharing and Third Parties'>
-          <Text mb={4}>We share your data with the following third parties:</Text>
+        <LegalSection title='8. Weitergabe von Daten an Dritte'>
+          <Text mb={4}>Wir geben Ihre Daten an folgende Drittanbieter weiter:</Text>
           <UnorderedList spacing={4} mb={4}>
             <ListItem>
               <Text fontWeight='semibold' as='span'>Stripe: </Text>
-              For payment processing
+              Zur Zahlungsabwicklung
             </ListItem>
             <ListItem>
               <Text fontWeight='semibold' as='span'>OpenAI: </Text>
-              For AI-powered content generation
+              Für die KI-gestützte Inhaltserstellung
             </ListItem>
           </UnorderedList>
           <Text>
-            All third parties are contractually obligated to protect your data and 
-            may only use it for specified purposes.
+            Alle Dritten sind vertraglich verpflichtet, Ihre Daten zu schützen und
+            sie nur zu den angegebenen Zwecken zu verwenden.
           </Text>
         </LegalSection>
 
-        <LegalSection title='9. International Data Transfers'>
+        <LegalSection title='9. Internationale Datenübermittlungen'>
           <Text mb={4}>
-            Your data may be transferred to and processed in countries outside the EU. 
-            When this occurs, we ensure appropriate safeguards are in place through:
+            Ihre Daten können in Länder außerhalb der EU übermittelt und dort verarbeitet werden.
+            Dabei stellen wir geeignete Schutzmaßnahmen sicher durch:
           </Text>
           <UnorderedList spacing={2}>
-            <ListItem>EU Standard Contractual Clauses</ListItem>
-            <ListItem>Adequacy decisions by the European Commission</ListItem>
-            <ListItem>Other legally recognized transfer mechanisms</ListItem>
+            <ListItem>EU-Standardvertragsklauseln</ListItem>
+            <ListItem>Angemessenheitsbeschlüsse der Europäischen Kommission</ListItem>
+            <ListItem>Andere gesetzlich anerkannte Übermittlungsmechanismen</ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title='10. Cookies and Tracking'>
+        <LegalSection title='10. Cookies und Tracking'>
           <Text mb={4}>
-            Our service does not use cookies or tracking technologies. We prioritize your privacy 
-            and have designed our service to function without the need for cookies or similar 
-            tracking mechanisms.
+            Unser Dienst verwendet keine Cookies oder Tracking-Technologien. Wir legen großen Wert auf Ihre Privatsphäre
+            und haben den Service so gestaltet, dass er ohne Cookies oder ähnliche Mechanismen funktioniert.
           </Text>
           <Text>
-            Any essential session management is handled securely through standard authentication 
-            tokens that are automatically cleared when you log out or close your browser.
+            Notwendige Sitzungen werden sicher über standardisierte Authentifizierungs-Token verwaltet,
+            die automatisch gelöscht werden, wenn Sie sich abmelden oder den Browser schließen.
           </Text>
         </LegalSection>
 
-        <LegalSection title='11. Data Security'>
+        <LegalSection title='11. Datensicherheit'>
           <Text mb={4}>
-            We implement appropriate technical and organizational measures to protect 
-            your personal data, including:
+            Wir ergreifen angemessene technische und organisatorische Maßnahmen zum Schutz Ihrer Daten, darunter:
           </Text>
           <UnorderedList spacing={2}>
-            <ListItem>Regular security assessments</ListItem>
-            <ListItem>Access controls and authentication</ListItem>
-            <ListItem>Regular backups</ListItem>
-            <ListItem>Staff training on data protection</ListItem>
+            <ListItem>Regelmäßige Sicherheitsüberprüfungen</ListItem>
+            <ListItem>Zugangskontrollen und Authentifizierung</ListItem>
+            <ListItem>Regelmäßige Backups</ListItem>
+            <ListItem>Schulung unserer Mitarbeitenden zum Datenschutz</ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title='12. Changes to This Privacy Policy'>
+        <LegalSection title='12. Änderungen dieser Datenschutzerklärung'>
           <Text mb={4}>
-            We may update our Privacy Policy from time to time. We will notify you of 
-            any changes by posting the new Privacy Policy on this page and updating 
-            the "Last updated" date.
+            Wir können diese Datenschutzerklärung gelegentlich anpassen. Über Änderungen informieren wir,
+            indem wir die neue Fassung auf dieser Seite veröffentlichen und das Datum der letzten Aktualisierung anpassen.
           </Text>
           <Text>
-            You are advised to review this Privacy Policy periodically for any changes. 
-            Changes to this Privacy Policy are effective when they are posted on this page.
+            Bitte prüfen Sie diese Seite regelmäßig. Änderungen treten in Kraft, sobald sie hier veröffentlicht werden.
           </Text>
         </LegalSection>
 
-        <LegalSection title='13. Contact Us'>
+        <LegalSection title='13. Kontakt'>
           <Text mb={4}>
-            If you have any questions about this Privacy Policy or our data practices, 
-            please contact us:
+            Wenn Sie Fragen zu dieser Datenschutzerklärung oder unseren Datenschutzpraktiken haben,
+            kontaktieren Sie uns bitte:
           </Text>
           <UnorderedList spacing={2} mb={4}>
-            <ListItem>
-              By email: info.crimpin@gmail.com
-            </ListItem>
-            <ListItem>
-              By mail: Canger & Shahab Crimpin GbR, Zum Steinberg 12, 69121 Heidelberg, Germany
-            </ListItem>
+            <ListItem>Per E-Mail: info.crimpin@gmail.com</ListItem>
+            <ListItem>Per Post: Canger & Shahab Crimpin GbR, Zum Steinberg 12, 69121 Heidelberg, Deutschland</ListItem>
           </UnorderedList>
           <Text>
-            You have the right to lodge a complaint with a supervisory authority if you 
-            believe our processing of your personal data violates data protection laws.
+            Sie haben zudem das Recht, sich bei einer Aufsichtsbehörde zu beschweren,
+            falls Sie der Ansicht sind, dass wir Ihre Daten nicht datenschutzkonform verarbeiten.
           </Text>
         </LegalSection>
       </VStack>

--- a/src/client/legal/TosPage.tsx
+++ b/src/client/legal/TosPage.tsx
@@ -24,13 +24,13 @@ const TermsOfService = () => {
 
         <LegalSection title='1. Unternehmensangaben (Impressum)'>
           <Text>
-            Canger & Shahab Crimpin GbR
+           GbR
             <br />
-            Zum Steinberg 12, 69121 Heidelberg, Deutschland
+            Deutschland
             <br />
-            E-Mail: info.crimpin@gmail.com
+            E-Mail: @gmail.com
             <br />
-            Vertretungsberechtigte Gesellschafter: Canger & Shahab Crimpin GbR
+             GbR
           </Text>
         </LegalSection>
 
@@ -108,9 +108,9 @@ const TermsOfService = () => {
               <VStack align='stretch' spacing={4} color='text-contrast-lg'>
                 <Box>
                   <Text fontWeight='medium'>An:</Text>
-                  <Text>Canger & Shahab Crimpin GbR</Text>
-                  <Text>Zum Steinberg 12, 69121 Heidelberg, Deutschland</Text>
-                  <Text>E-Mail: info.crimpin@gmail.com</Text>
+                  <Text>CGbR</Text>
+                  <Text> Deutschland</Text>
+                  <Text>gmail.com</Text>
                 </Box>
 
                 <Text>

--- a/src/client/legal/TosPage.tsx
+++ b/src/client/legal/TosPage.tsx
@@ -19,273 +19,235 @@ const TermsOfService = () => {
   return (
     <BorderBox>
       <VStack maxW='4xl' mx='auto' p={6} spacing={6} align='flex-start'>
-        <Heading as='h1' size='xl' mb={6}>Terms of Service</Heading>
+        <Heading as='h1' size='xl' mb={6}>Nutzungsbedingungen</Heading>
         <Text fontSize='sm' color='gray.600' mb={6}>Last updated: {new Date().toLocaleDateString()}</Text>
 
-        <LegalSection title='1. Company Information (Impressum)'>
+        <LegalSection title='1. Unternehmensangaben (Impressum)'>
           <Text>
             Canger & Shahab Crimpin GbR
             <br />
-            Zum Steinberg 12, 69121 Heidelberg, Germany
+            Zum Steinberg 12, 69121 Heidelberg, Deutschland
             <br />
-            Email: info.crimpin@gmail@.com
+            E-Mail: info.crimpin@gmail.com
             <br />
-            Partners: Canger & Shahab Crimpin GbR
+            Vertretungsberechtigte Gesellschafter: Canger & Shahab Crimpin GbR
           </Text>
         </LegalSection>
 
-        <LegalSection title='2. Description of Service'>
+        <LegalSection title='2. Leistungsbeschreibung'>
           <Text>
-            CoverLetterGPT is a SaaS application that uses AI technology to assist users in creating personalized cover letter examples based on their curriculum vitae (CV) and job descriptions. The service is provided from
-            Germany and is subject to German law.
+            CoverLetterGPT ist eine SaaS-Anwendung, die KI-Technologie nutzt, um Nutzern Beispielanschreiben auf Basis ihres Lebenslaufs und von Stellenbeschreibungen zu erstellen. Der Dienst wird in Deutschland betrieben und unterliegt deutschem Recht.
           </Text>
         </LegalSection>
 
-        <LegalSection title='3. Contract Formation'>
-          <Text>By registering for our service, you enter into a legally binding contract with Canger & Shahab Crimpin GbR under German law. The contract is formed when we confirm your registration via email.</Text>
+        <LegalSection title='3. Vertragsschluss'>
+          <Text>Mit Ihrer Registrierung kommt unter deutschem Recht ein verbindlicher Vertrag mit der Canger & Shahab Crimpin GbR zustande. Der Vertrag gilt als geschlossen, sobald wir Ihre Anmeldung per E-Mail bestätigen.</Text>
         </LegalSection>
 
-        <LegalSection title='4. User Account and Data Protection'>
-          <Text>To use CoverLetterGPT, you must register for an account and provide accurate and complete information. You are responsible for maintaining the confidentiality of your account and password.</Text>
+        <LegalSection title='4. Nutzerkonto und Datenschutz'>
+          <Text>Zur Nutzung von CoverLetterGPT ist ein Benutzerkonto erforderlich. Sie müssen hierbei korrekte und vollständige Angaben machen und sind für die Geheimhaltung Ihrer Zugangsdaten verantwortlich.</Text>
         </LegalSection>
 
-        <LegalSection title='5. Prices and Payment Terms'>
+        <LegalSection title='5. Preise und Zahlungsbedingungen'>
           <Text>
-            Prices are displayed in your local currency where available, with EUR being our base currency. 
-            All prices include applicable taxes (such as VAT for EU customers). Charges for our services 
-            are billed monthly. Your subscription will automatically renew each month unless cancelled 
-            at least one day before the renewal date.
+            Die Preise werden, soweit möglich, in Ihrer lokalen Währung angezeigt, unsere Basiswährung ist jedoch EUR.
+            Sämtliche Preise verstehen sich inklusive der gesetzlichen Steuern (z.B. Mehrwertsteuer für EU-Kunden).
+            Die Abrechnung unserer Leistungen erfolgt monatlich. Ihr Abonnement verlängert sich automatisch,
+            sofern es nicht mindestens einen Tag vor dem Verlängerungsdatum gekündigt wird.
           </Text>
           <UnorderedList mt={2} spacing={2} pl={5}>
             <ListItem>
-              Prices shown are converted to your local currency based on current exchange rates
+              Angezeigte Preise werden anhand aktueller Wechselkurse in Ihre Währung umgerechnet
             </ListItem>
             <ListItem>
-              The final charge may vary slightly due to exchange rate fluctuations and conversion fees
+              Der endgültige Betrag kann aufgrund von Wechselkursschwankungen und Umrechnungsgebühren geringfügig abweichen
             </ListItem>
             <ListItem>
-              For EU customers, prices include applicable Value Added Tax (VAT)
+              Für EU-Kunden enthalten die Preise die gesetzliche Mehrwertsteuer
             </ListItem>
             <ListItem>
-              For non-EU customers, additional taxes may apply according to local regulations
+              Für Kunden außerhalb der EU können je nach lokalen Vorschriften weitere Steuern anfallen
             </ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title='6. Right of Withdrawal and Withdrawal Form'>
+        <LegalSection title='6. Widerrufsrecht und Muster-Widerrufsformular'>
           <VStack spacing={6} align='stretch'>
             <Box>
               <Text>
-                As a consumer within the EU, you have the right to withdraw from this contract 
-                within 14 days without giving any reason. The withdrawal period expires after 
-                14 days from the day of contract conclusion.
+                Als Verbraucher innerhalb der EU haben Sie das Recht, diesen Vertrag innerhalb von
+                14 Tagen ohne Angabe von Gründen zu widerrufen. Die Widerrufsfrist endet 14 Tage nach
+                dem Tag des Vertragsschlusses.
               </Text>
               
               <Text mt={4}>
-                To exercise your right of withdrawal, you must inform us of your decision to 
-                withdraw from this contract by an unequivocal statement (e.g., a letter sent 
-                by post or email). You may use the model withdrawal form provided below, 
-                but it is not obligatory.
+                Um Ihr Widerrufsrecht auszuüben, müssen Sie uns mittels einer eindeutigen Erklärung
+                (z.B. ein Brief per Post oder E-Mail) über Ihren Entschluss informieren. Sie können dafür
+                das nachstehende Muster-Widerrufsformular verwenden, was jedoch nicht vorgeschrieben ist.
               </Text>
 
               <Text mt={4}>
-                To meet the withdrawal deadline, it is sufficient for you to send your 
-                communication concerning your exercise of the right of withdrawal before the 
-                withdrawal period has expired.
+                Zur Wahrung der Frist reicht es aus, dass Sie die Mitteilung über die Ausübung des Widerrufsrechts
+                vor Ablauf der Widerrufsfrist absenden.
               </Text>
 
               <Text mt={4}>
-                Effects of withdrawal: If you withdraw from this contract, we shall reimburse 
-                to you all payments received from you, including the costs of delivery (with 
-                the exception of the supplementary costs resulting from your choice of a type 
-                of delivery other than the least expensive type of standard delivery offered 
-                by us), without undue delay and in any event not later than 14 days from the 
-                day on which we are informed about your decision to withdraw from this contract.
+                Folgen des Widerrufs: Wenn Sie diesen Vertrag widerrufen, erstatten wir Ihnen alle Zahlungen,
+                einschließlich der Lieferkosten (mit Ausnahme zusätzlicher Kosten, die sich daraus ergeben,
+                dass Sie eine andere Art der Lieferung als die von uns angebotene günstigste Standardlieferung
+                gewählt haben), unverzüglich und spätestens binnen 14 Tagen ab dem Tag, an dem die Mitteilung
+                über Ihren Widerruf bei uns eingegangen ist.
               </Text>
             </Box>
 
             <Box p={4} borderWidth={1} borderRadius='lg' bg='bg-contrast-sm'>
-              <Text fontWeight='semibold' mb={4}>
-                Model Withdrawal Form
-              </Text>
+              <Text fontWeight='semibold' mb={4}>Muster-Widerrufsformular</Text>
               <Text mb={4}>
-                (Complete and return this form only if you wish to withdraw from the contract)
+                (Bitte senden Sie dieses Formular nur zurück, wenn Sie den Vertrag widerrufen möchten)
               </Text>
               <VStack align='stretch' spacing={4} color='text-contrast-lg'>
                 <Box>
-                  <Text fontWeight='medium'>To:</Text>
+                  <Text fontWeight='medium'>An:</Text>
                   <Text>Canger & Shahab Crimpin GbR</Text>
-                  <Text>Zum Steinberg 12, 69121 Heidelberg, Germany</Text>
-                  <Text>Email: info.crimpin@gmail.com</Text>
+                  <Text>Zum Steinberg 12, 69121 Heidelberg, Deutschland</Text>
+                  <Text>E-Mail: info.crimpin@gmail.com</Text>
                 </Box>
 
                 <Text>
-                  I/We (*) hereby give notice that I/We (*) withdraw from my/our (*) contract 
-                  for the provision of the following service: CoverLetterGPT subscription.
+                  Hiermit widerrufe(n) ich/wir (*) den von mir/uns (*) abgeschlossenen Vertrag über die Erbringung der folgenden Dienstleistung: CoverLetterGPT-Abonnement.
                 </Text>
 
                 <UnorderedList spacing={2} pl={4}>
-                  <ListItem>Ordered on (*)/received on (*)</ListItem>
-                  <ListItem>Name of consumer(s)</ListItem>
-                  <ListItem>Address of consumer(s)</ListItem>
-                  <ListItem>Signature of consumer(s) (only if this form is notified on paper)</ListItem>
-                  <ListItem>Date</ListItem>
+                  <ListItem>Bestellt am (*)/erhalten am (*)</ListItem>
+                  <ListItem>Name des/der Verbraucher(s)</ListItem>
+                  <ListItem>Anschrift des/der Verbraucher(s)</ListItem>
+                  <ListItem>Unterschrift des/der Verbraucher(s) (nur bei Mitteilung auf Papier)</ListItem>
+                  <ListItem>Datum</ListItem>
                 </UnorderedList>
 
-                <Text fontSize='sm' fontStyle='italic'>
-                  (*) Delete as appropriate
-                </Text>
+                <Text fontSize='sm' fontStyle='italic'>(*) Unzutreffendes streichen.</Text>
               </VStack>
             </Box>
 
             <Text fontSize='sm' color='gray.600'>
-              To exercise your right of withdrawal, you may use the above model form, but 
-              it is not obligatory. You may also submit any other clear statement of your 
-              decision to withdraw from the contract via email or our contact form.
+              Zur Ausübung Ihres Widerrufsrechts können Sie das oben stehende Muster verwenden, dies ist jedoch nicht verpflichtend. Sie können uns Ihren Widerruf auch in anderer Form per E-Mail oder über unser Kontaktformular zukommen lassen.
             </Text>
           </VStack>
         </LegalSection>
 
-        <LegalSection title='7. Dispute Resolution'>
+        <LegalSection title='7. Streitbeilegung'>
           <Text>
-            The European Commission provides a platform for online dispute resolution (OS) which is available at https://ec.europa.eu/consumers/odr/. We are neither obligated nor willing to participate in dispute
-            resolution proceedings before a consumer arbitration board.
+            Die Europäische Kommission stellt unter https://ec.europa.eu/consumers/odr/ eine Plattform zur Online-Streitbeilegung bereit. Wir sind weder verpflichtet noch bereit, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.
           </Text>
         </LegalSection>
 
-        <LegalSection title='8. Governing Law'>
-          <Text>These Terms are governed by German law. The application of the UN Convention on Contracts for the International Sale of Goods is excluded.</Text>
+        <LegalSection title='8. Anwendbares Recht'>
+          <Text>Diese Bedingungen unterliegen deutschem Recht. Die Anwendung des UN-Kaufrechts ist ausgeschlossen.</Text>
         </LegalSection>
 
-        <LegalSection title='9. Service Usage and Limitations'>
+        <LegalSection title='9. Nutzung des Dienstes und Einschränkungen'>
           <Text>
-            CoverLetterGPT provides AI-assisted cover letter generation services. Users 
-            acknowledge and agree to the following terms of use:
+            CoverLetterGPT bietet KI-gestützte Unterstützung bei der Erstellung von Anschreiben. Nutzer erkennen die folgenden Nutzungsbedingungen an:
           </Text>
           <UnorderedList spacing={2} pl={5}>
             <ListItem>
-              The service is provided for example and learning purposes only. Cover letters 
-              generated through our service are meant to serve as templates and examples.
+              Der Dienst dient ausschließlich zu Beispiel- und Lernzwecken. Die generierten Anschreiben sind lediglich Vorlagen.
             </ListItem>
             <ListItem>
-              Users are strongly advised NOT to use AI-generated cover letters directly 
-              for job applications without substantial personal modification and review.
+              Nutzer sollten die AI-generierten Anschreiben nicht unverändert für Bewerbungen verwenden, sondern sie sorgfältig anpassen und prüfen.
             </ListItem>
             <ListItem>
-              We reserve the right to limit, suspend, or terminate access to the service 
-              at our discretion if we detect abuse or violation of these terms.
+              Wir behalten uns vor, den Zugang zum Dienst einzuschränken oder zu sperren, wenn Missbrauch oder Verstöße gegen diese Bedingungen festgestellt werden.
             </ListItem>
             <ListItem>
-              Users are responsible for maintaining the confidentiality of their account 
-              credentials and may not share their account with others.
+              Nutzer sind dafür verantwortlich, ihre Zugangsdaten geheim zu halten und ihr Konto nicht mit Dritten zu teilen.
             </ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title='10. Disclaimer of Liability'>
+        <LegalSection title='10. Haftungsausschluss'>
           <Text>
-            To the maximum extent permitted by applicable law:
+            Soweit gesetzlich zulässig, gilt Folgendes:
           </Text>
           <UnorderedList spacing={2} pl={5}>
             <ListItem>
-              The cover letters generated through our service are provided "AS IS" and 
-              "AS AVAILABLE" without any warranties, express or implied.
+              Die von unserem Dienst erzeugten Anschreiben werden ohne Gewähr bereitgestellt.
             </ListItem>
             <ListItem>
-              We explicitly disclaim any liability for the content, accuracy, or 
-              appropriateness of the generated cover letters for any specific purpose, 
-              including but not limited to job applications.
+              Wir übernehmen keine Haftung für Inhalt, Richtigkeit oder Eignung der generierten Anschreiben für einen bestimmten Zweck, insbesondere nicht für Bewerbungen.
             </ListItem>
             <ListItem>
-              Users assume full responsibility for any use, modification, or submission 
-              of the generated cover letters in job applications or other professional 
-              contexts.
+              Die Verwendung, Anpassung oder Einreichung der Anschreiben erfolgt auf eigene Verantwortung der Nutzer.
             </ListItem>
             <ListItem>
-              We are not liable for any consequences, direct or indirect, arising from 
-              the use of our service, including but not limited to:
+              Wir haften nicht für direkte oder indirekte Folgen der Nutzung unseres Dienstes, insbesondere nicht für:
               <UnorderedList mt={2} pl={5}>
-                <ListItem>Missed job opportunities</ListItem>
-                <ListItem>Rejected applications</ListItem>
-                <ListItem>Professional reputation impact</ListItem>
-                <ListItem>Loss of potential income</ListItem>
-                <ListItem>Any misrepresentation in generated content</ListItem>
-                <ListItem>Technical errors or service interruptions</ListItem>
-                <ListItem>Data loss or security breaches</ListItem>
+                <ListItem>verpasste Jobchancen</ListItem>
+                <ListItem>abgelehnte Bewerbungen</ListItem>
+                <ListItem>Beeinträchtigung des beruflichen Rufs</ListItem>
+                <ListItem>entgangene Einnahmen</ListItem>
+                <ListItem>etwaige Falschdarstellungen in den generierten Inhalten</ListItem>
+                <ListItem>technische Fehler oder Serviceunterbrechungen</ListItem>
+                <ListItem>Datenverlust oder Sicherheitsverletzungen</ListItem>
               </UnorderedList>
             </ListItem>
             <ListItem>
-              While we strive to maintain high accuracy and quality, AI-generated content may 
-              contain errors, inconsistencies, or inappropriate content. Users are strongly 
-              advised to thoroughly review and modify all generated content before use.
+              Trotz größter Sorgfalt kann AI-generierter Inhalt Fehler oder unangemessene Passagen enthalten. Prüfen und bearbeiten Sie daher alle Texte vor einer Verwendung sorgfältig.
             </ListItem>
             <ListItem>
-              We do not guarantee that our service will meet your specific requirements or 
-              expectations, or that it will be compatible with your particular job application 
-              needs.
+              Wir garantieren nicht, dass unser Dienst Ihre individuellen Anforderungen erfüllt oder mit speziellen Bewerbungsanforderungen kompatibel ist.
             </ListItem>
             <ListItem>
-              Our total liability, if any, shall not exceed the amount paid by you 
-              for the service in the month preceding the incident.
+              Unsere Haftung ist, soweit gesetzlich zulässig, auf den Betrag beschränkt, den Sie im Monat vor dem Vorfall für den Dienst gezahlt haben.
             </ListItem>
             <ListItem>
-              Some jurisdictions do not allow the exclusion of certain warranties or 
-              limitations on applicable statutory rights of a consumer, so some or all 
-              of the above exclusions and limitations may not apply to you.
+              In einigen Rechtsordnungen sind bestimmte Haftungsbeschränkungen nicht zulässig; gegebenenfalls gelten die vorstehenden Ausschlüsse daher für Sie nicht.
             </ListItem>
           </UnorderedList>
           <Text mt={4} fontWeight='semibold'>
-            By using our service, you explicitly acknowledge and accept these limitations 
-            and disclaimers.
+            Durch die Nutzung unseres Dienstes erkennen Sie diese Beschränkungen und Haftungsausschlüsse ausdrücklich an.
           </Text>
         </LegalSection>
 
-        <LegalSection title='11. Intellectual Property'>
+        <LegalSection title='11. Geistiges Eigentum'>
           <UnorderedList spacing={2} pl={5}>
             <ListItem>
-              The service, including all software, algorithms, and interface designs, 
-              remains the exclusive property of Canger & Shahab Crimpin GbR.
+              Der Dienst einschließlich aller Software, Algorithmen und Oberflächen bleibt ausschließliches Eigentum der Canger & Shahab Crimpin GbR.
             </ListItem>
             <ListItem>
-              While users retain rights to their personal information and modified cover 
-              letters, the AI-generated content templates are provided under a limited, 
-              non-exclusive license for personal use only.
+              Nutzer behalten die Rechte an ihren eigenen Daten und bearbeiteten Anschreiben; die von der KI generierten Vorlagen werden jedoch nur für die persönliche Nutzung unter einer einfachen Lizenz bereitgestellt.
             </ListItem>
             <ListItem>
-              Users may not reproduce, distribute, or commercialize the service or its 
-              outputs without explicit written permission.
+              Eine Vervielfältigung, Verbreitung oder kommerzielle Nutzung des Dienstes oder seiner Ergebnisse ist ohne ausdrückliche schriftliche Genehmigung untersagt.
             </ListItem>
           </UnorderedList>
         </LegalSection>
 
-        <LegalSection title="12. Security">
+        <LegalSection title="12. Sicherheit">
           <Text>
-            CoverLetterGPT does not process any order payments directly through the website. 
-            All payments are processed securely through Stripe, a third party online 
-            payment provider. When processing payments:
+            CoverLetterGPT verarbeitet keine Zahlungen direkt auf der Website. Alle Zahlungen erfolgen sicher über Stripe als externen Zahlungsanbieter. Bei der Abwicklung gelten folgende Punkte:
           </Text>
           <UnorderedList spacing={2} pl={5}>
             <ListItem>
-              Your payment information is never stored on our servers
+              Ihre Zahlungsinformationen werden nie auf unseren Servern gespeichert
             </ListItem>
             <ListItem>
-              All payment transactions are encrypted and processed securely by Stripe
+              Sämtliche Transaktionen werden verschlüsselt und sicher von Stripe durchgeführt
             </ListItem>
             <ListItem>
-              Stripe is a PCI Service Provider Level 1, which is the highest grade of 
-              payment processing security
+              Stripe ist als PCI Service Provider Level 1 zertifiziert und erfüllt damit höchste Sicherheitsstandards
             </ListItem>
             <ListItem>
-              For more information about Stripe's security measures, please visit 
-              <Link 
-                href="https://stripe.com/docs/security" 
-                target="_blank" 
+              Weitere Informationen zu den Sicherheitsmaßnahmen von Stripe finden Sie unter
+              <Link
+                href="https://stripe.com/docs/security"
+                target="_blank"
                 rel="noopener noreferrer"
                 color="purple.600"
                 _hover={{ color: 'purple.800' }}
                 ml={1}
               >
-                Stripe's Security Documentation
+                Stripes Sicherheitsdokumentation
               </Link>
             </ListItem>
           </UnorderedList>


### PR DESCRIPTION
## Summary
- localize navigation and footer labels
- update dialogs, modals and forms with German text
- adjust page headings and buttons for German UI
- fully localize legal pages for German market

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859b9d9434c8323b31281ef312e59b0